### PR TITLE
feat(practice): modelos y adaptadores hive para sesiones de práctica (grupo de tareas 3.1)

### DIFF
--- a/docs/tasks-prd-sgs-golf.md
+++ b/docs/tasks-prd-sgs-golf.md
@@ -134,17 +134,17 @@
     - [x] 2.4.1 Crear `auth_provider.dart` con estados de carga, error y autenticado
     - [x] 2.4.2 Integrar Provider con widgets para reflejar cambios de estado
     - [x] 2.4.3 Implementar manejo de errores y mensajes al usuario
-  - [ ] 2.5 Pruebas:
-    - [ ] 2.5.1 Escribir pruebas unitarias para `AuthRepository`
-    - [ ] 2.5.2 Escribir pruebas de widget para `login_screen.dart` y `register_screen.dart`
-    - [ ] 2.5.3 Probar flujos de error y validación
+  - [x] 2.5 Pruebas:
+    - [x] 2.5.1 Escribir pruebas unitarias para `AuthRepository`
+    - [x] 2.5.2 Escribir pruebas de widget para `login_screen.dart` y `register_screen.dart`
+    - [x] 2.5.3 Probar flujos de error y validación
 
 - [ ] 3.0 Desarrollo del Módulo de Sesiones de Práctica (Core de la Aplicación)
-  - [ ] 3.1 Modelado de datos clave:
-    - [ ] 3.1.1 Definir enum `GolfClubType` para palos (PW, GW, SW, LW)
-    - [ ] 3.1.2 Crear modelo `Shot` con campos para tipo de palo, distancia y timestamp
-    - [ ] 3.1.3 Implementar `PracticeSession` con fecha, duración, lista de tiros y resumen
-    - [ ] 3.1.4 Diseñar adaptadores Hive para todos los modelos
+  - [x] 3.1 Modelado de datos clave:
+    - [x] 3.1.1 Definir enum `GolfClubType` para palos (PW, GW, SW, LW)
+    - [x] 3.1.2 Crear modelo `Shot` con campos para tipo de palo, distancia y timestamp
+    - [x] 3.1.3 Implementar `PracticeSession` con fecha, duración, lista de tiros y resumen
+    - [x] 3.1.4 Diseñar adaptadores Hive para todos los modelos
   - [ ] 3.2 Lógica de negocio para sesiones:
     - [ ] 3.2.1 Crear `PracticeRepository` para la gestión CRUD de sesiones
     - [ ] 3.2.2 Implementar métodos para añadir tiros a una sesión activa

--- a/lib/data/models/golf_club.dart
+++ b/lib/data/models/golf_club.dart
@@ -2,6 +2,31 @@ import 'package:hive/hive.dart';
 
 part 'golf_club.g.dart';
 
+/// Enum que representa los tipos de palos de golf utilizados en práctica.
+///
+/// - [pw]: Pitching Wedge
+/// - [gw]: Gap Wedge
+/// - [sw]: Sand Wedge
+/// - [lw]: Lob Wedge
+@HiveType(typeId: 10)
+enum GolfClubType {
+  /// Pitching Wedge
+  @HiveField(0)
+  pw,
+
+  /// Gap Wedge
+  @HiveField(1)
+  gw,
+
+  /// Sand Wedge
+  @HiveField(2)
+  sw,
+
+  /// Lob Wedge
+  @HiveField(3)
+  lw,
+}
+
 @HiveType(typeId: 1)
 class GolfClub extends HiveObject {
   @HiveField(0)

--- a/lib/data/models/golf_club.g.dart
+++ b/lib/data/models/golf_club.g.dart
@@ -45,3 +45,52 @@ class GolfClubAdapter extends TypeAdapter<GolfClub> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
+
+class GolfClubTypeAdapter extends TypeAdapter<GolfClubType> {
+  @override
+  final int typeId = 10;
+
+  @override
+  GolfClubType read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return GolfClubType.pw;
+      case 1:
+        return GolfClubType.gw;
+      case 2:
+        return GolfClubType.sw;
+      case 3:
+        return GolfClubType.lw;
+      default:
+        return GolfClubType.pw;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, GolfClubType obj) {
+    switch (obj) {
+      case GolfClubType.pw:
+        writer.writeByte(0);
+        break;
+      case GolfClubType.gw:
+        writer.writeByte(1);
+        break;
+      case GolfClubType.sw:
+        writer.writeByte(2);
+        break;
+      case GolfClubType.lw:
+        writer.writeByte(3);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GolfClubTypeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/data/models/practice_session.dart
+++ b/lib/data/models/practice_session.dart
@@ -1,25 +1,53 @@
 import 'package:hive/hive.dart';
-
+import 'package:sgs_golf/data/models/shot.dart';
 part 'practice_session.g.dart';
 
+/// Adaptador Hive para Duration
+class DurationAdapter extends TypeAdapter<Duration> {
+  @override
+  final int typeId = 99;
+
+  @override
+  Duration read(BinaryReader reader) {
+    final microseconds = reader.readInt();
+    return Duration(microseconds: microseconds);
+  }
+
+  @override
+  void write(BinaryWriter writer, Duration obj) {
+    writer.writeInt(obj.inMicroseconds);
+  }
+}
+
+/// Modelo que representa una sesión completa de práctica de golf.
 @HiveType(typeId: 3)
 class PracticeSession extends HiveObject {
+  /// Fecha de la sesión
   @HiveField(0)
-  String id;
-
-  @HiveField(1)
-  String userId;
-
-  @HiveField(2)
   DateTime date;
 
+  /// Duración de la sesión
+  @HiveField(1)
+  Duration duration;
+
+  /// Lista de tiros realizados en la sesión
+  @HiveField(2)
+  List<Shot> shots;
+
+  /// Resumen de la sesión (puede ser un string o un objeto simple)
   @HiveField(3)
-  List<String> shotIds;
+  String summary;
 
   PracticeSession({
-    required this.id,
-    required this.userId,
     required this.date,
-    required this.shotIds,
+    required this.duration,
+    required this.shots,
+    required this.summary,
   });
+
+  /// Calcula el número total de tiros
+  int get totalShots => shots.length;
+
+  /// Calcula la distancia total de la sesión
+  double get totalDistance => shots.fold(0, (sum, s) => sum + s.distance);
 }

--- a/lib/data/models/practice_session.g.dart
+++ b/lib/data/models/practice_session.g.dart
@@ -17,10 +17,10 @@ class PracticeSessionAdapter extends TypeAdapter<PracticeSession> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return PracticeSession(
-      id: fields[0] as String,
-      userId: fields[1] as String,
-      date: fields[2] as DateTime,
-      shotIds: (fields[3] as List).cast<String>(),
+      date: fields[0] as DateTime,
+      duration: fields[1] as Duration,
+      shots: (fields[2] as List).cast<Shot>(),
+      summary: fields[3] as String,
     );
   }
 
@@ -29,13 +29,13 @@ class PracticeSessionAdapter extends TypeAdapter<PracticeSession> {
     writer
       ..writeByte(4)
       ..writeByte(0)
-      ..write(obj.id)
-      ..writeByte(1)
-      ..write(obj.userId)
-      ..writeByte(2)
       ..write(obj.date)
+      ..writeByte(1)
+      ..write(obj.duration)
+      ..writeByte(2)
+      ..write(obj.shots)
       ..writeByte(3)
-      ..write(obj.shotIds);
+      ..write(obj.summary);
   }
 
   @override

--- a/lib/data/models/shot.dart
+++ b/lib/data/models/shot.dart
@@ -1,25 +1,30 @@
 import 'package:hive/hive.dart';
+import 'package:sgs_golf/data/models/golf_club.dart';
 
 part 'shot.g.dart';
 
+/// Modelo que representa un tiro individual en una sesión de práctica.
 @HiveType(typeId: 2)
 class Shot extends HiveObject {
+  /// Tipo de palo utilizado para el tiro
   @HiveField(0)
-  String id;
+  GolfClubType clubType;
 
+  /// Distancia alcanzada en metros
   @HiveField(1)
-  String clubId;
-
-  @HiveField(2)
   double distance;
 
-  @HiveField(3)
+  /// Marca de tiempo del tiro
+  @HiveField(2)
   DateTime timestamp;
 
   Shot({
-    required this.id,
-    required this.clubId,
+    required this.clubType,
     required this.distance,
     required this.timestamp,
   });
+
+  @override
+  String toString() =>
+      'Shot(clubType: $clubType, distance: $distance, timestamp: $timestamp)';
 }

--- a/lib/data/models/shot.g.dart
+++ b/lib/data/models/shot.g.dart
@@ -17,24 +17,21 @@ class ShotAdapter extends TypeAdapter<Shot> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Shot(
-      id: fields[0] as String,
-      clubId: fields[1] as String,
-      distance: fields[2] as double,
-      timestamp: fields[3] as DateTime,
+      clubType: fields[0] as GolfClubType,
+      distance: fields[1] as double,
+      timestamp: fields[2] as DateTime,
     );
   }
 
   @override
   void write(BinaryWriter writer, Shot obj) {
     writer
-      ..writeByte(4)
-      ..writeByte(0)
-      ..write(obj.id)
-      ..writeByte(1)
-      ..write(obj.clubId)
-      ..writeByte(2)
-      ..write(obj.distance)
       ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.clubType)
+      ..writeByte(1)
+      ..write(obj.distance)
+      ..writeByte(2)
       ..write(obj.timestamp);
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,8 +11,10 @@ Future<void> main() async {
 
   Hive.registerAdapter(UserAdapter());
   Hive.registerAdapter(GolfClubAdapter());
+  Hive.registerAdapter(GolfClubTypeAdapter());
   Hive.registerAdapter(ShotAdapter());
   Hive.registerAdapter(PracticeSessionAdapter());
+  Hive.registerAdapter(DurationAdapter());
 
   await Hive.openBox<User>('users');
   await Hive.openBox<GolfClub>('golfClubs');

--- a/test/data/models/golf_club_type_test.dart
+++ b/test/data/models/golf_club_type_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sgs_golf/data/models/golf_club.dart';
+
+void main() {
+  group('GolfClubType enum', () {
+    test('should contain all wedge types', () {
+      expect(GolfClubType.values.length, 4);
+      expect(GolfClubType.pw.toString(), 'GolfClubType.pw');
+      expect(GolfClubType.gw.toString(), 'GolfClubType.gw');
+      expect(GolfClubType.sw.toString(), 'GolfClubType.sw');
+      expect(GolfClubType.lw.toString(), 'GolfClubType.lw');
+    });
+
+    test('should have correct index for each type', () {
+      expect(GolfClubType.pw.index, 0);
+      expect(GolfClubType.gw.index, 1);
+      expect(GolfClubType.sw.index, 2);
+      expect(GolfClubType.lw.index, 3);
+    });
+  });
+}

--- a/test/data/models/hive_adapters_test.dart
+++ b/test/data/models/hive_adapters_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:sgs_golf/data/models/golf_club.dart';
+import 'package:sgs_golf/data/models/practice_session.dart';
+import 'package:sgs_golf/data/models/shot.dart';
+
+void main() {
+  group('Hive adapters (persistencia real)', () {
+    test(
+      'GolfClubType, Shot y PracticeSession persisten y leen correctamente',
+      () async {
+        Hive.init('test_hive');
+        Hive.registerAdapter(GolfClubTypeAdapter());
+        Hive.registerAdapter(ShotAdapter());
+        Hive.registerAdapter(PracticeSessionAdapter());
+        Hive.registerAdapter(DurationAdapter());
+
+        final box = await Hive.openBox<PracticeSession>('testPracticeSessions');
+        final shots = [
+          Shot(
+            clubType: GolfClubType.lw,
+            distance: 20,
+            timestamp: DateTime(2025, 7, 8, 12),
+          ),
+          Shot(
+            clubType: GolfClubType.pw,
+            distance: 50,
+            timestamp: DateTime(2025, 7, 8, 13),
+          ),
+        ];
+        final session = PracticeSession(
+          date: DateTime(2025, 7, 8),
+          duration: const Duration(minutes: 10),
+          shots: shots,
+          summary: '2 tiros',
+        );
+        await box.put('s1', session);
+        final loaded = box.get('s1');
+        expect(loaded, isNotNull);
+        expect(loaded!.shots.length, 2);
+        expect(loaded.shots.first.clubType, GolfClubType.lw);
+        expect(loaded.shots.last.clubType, GolfClubType.pw);
+        expect(loaded.summary, '2 tiros');
+        await box.deleteFromDisk();
+      },
+    );
+  });
+}

--- a/test/data/models/practice_session_test.dart
+++ b/test/data/models/practice_session_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sgs_golf/data/models/golf_club.dart';
+import 'package:sgs_golf/data/models/practice_session.dart';
+import 'package:sgs_golf/data/models/shot.dart';
+
+void main() {
+  group('PracticeSession model', () {
+    test('should create a valid PracticeSession instance', () {
+      final shots = [
+        Shot(
+          clubType: GolfClubType.pw,
+          distance: 50,
+          timestamp: DateTime(2025, 7, 8, 10),
+        ),
+        Shot(
+          clubType: GolfClubType.sw,
+          distance: 40,
+          timestamp: DateTime(2025, 7, 8, 10, 5),
+        ),
+      ];
+      final session = PracticeSession(
+        date: DateTime(2025, 7, 8),
+        duration: const Duration(minutes: 30),
+        shots: shots,
+        summary: '2 tiros, promedio 45m',
+      );
+      expect(session.date, DateTime(2025, 7, 8));
+      expect(session.duration, const Duration(minutes: 30));
+      expect(session.shots.length, 2);
+      expect(session.summary, contains('promedio'));
+    });
+
+    test('totalShots and totalDistance getters', () {
+      final shots = [
+        Shot(
+          clubType: GolfClubType.pw,
+          distance: 60,
+          timestamp: DateTime(2025, 7, 8, 10),
+        ),
+        Shot(
+          clubType: GolfClubType.gw,
+          distance: 55,
+          timestamp: DateTime(2025, 7, 8, 10, 10),
+        ),
+      ];
+      final session = PracticeSession(
+        date: DateTime(2025, 7, 8),
+        duration: const Duration(minutes: 20),
+        shots: shots,
+        summary: '2 tiros',
+      );
+      expect(session.totalShots, 2);
+      expect(session.totalDistance, 115);
+    });
+  });
+}

--- a/test/data/models/shot_test.dart
+++ b/test/data/models/shot_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sgs_golf/data/models/golf_club.dart';
+import 'package:sgs_golf/data/models/shot.dart';
+
+void main() {
+  group('Shot model', () {
+    test('should create a valid Shot instance', () {
+      final shot = Shot(
+        clubType: GolfClubType.sw,
+        distance: 45.5,
+        timestamp: DateTime.parse('2025-07-08T10:00:00Z'),
+      );
+      expect(shot.clubType, GolfClubType.sw);
+      expect(shot.distance, 45.5);
+      expect(shot.timestamp, DateTime.parse('2025-07-08T10:00:00Z'));
+    });
+
+    test('toString returns expected format', () {
+      final shot = Shot(
+        clubType: GolfClubType.pw,
+        distance: 60.0,
+        timestamp: DateTime(2025, 7, 8, 12),
+      );
+      expect(shot.toString(), contains('clubType: GolfClubType.pw'));
+      expect(shot.toString(), contains('distance: 60.0'));
+    });
+  });
+}


### PR DESCRIPTION
se implementaron los modelos clave para el módulo de sesiones de práctica:
- enum golfclubtype (pw, gw, sw, lw)
- modelo shot con tipo de palo, distancia y timestamp
- modelo practicesession con fecha, duración, lista de tiros y resumen
- adaptadores hive para todos los modelos, incluyendo duration
- registro de adaptadores en main.dart
- pruebas unitarias y funcionales para validación de persistencia y lógica

grupo de tareas 3.1 completado

este pr sienta la base de datos y persistencia para el core de la app, permitiendo la gestión y almacenamiento eficiente de sesiones de práctica y tiros.