### PR TITLE
feature(dashboard): añade pruebas para las acciones rápidas de navegación

### DIFF
--- a/test/features/dashboard/dashboard_screen_test.dart
+++ b/test/features/dashboard/dashboard_screen_test.dart
@@ -196,4 +196,121 @@ void main() {
     // Verificar que se vuelve a llamar al método getAllSessions
     verify(() => mockPracticeRepository.getAllSessions()).called(1);
   });
+
+  testWidgets('Navegación al hacer tap en botón de Práctica en dashboard', (
+    tester,
+  ) async {
+    // Configurar el mock
+    when(
+      () => mockPracticeRepository.getAllSessions(),
+    ).thenReturn(mockSessions);
+
+    // Preparar mapa de rutas para pruebas de navegación
+    final mockRoutes = {
+      '/practice': (context) => const Scaffold(
+        key: Key('practice-screen'),
+        body: Center(child: Text('Pantalla de Práctica')),
+      ),
+    };
+
+    // Crear el widget bajo test con el provider
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: mockRoutes,
+        home: ChangeNotifierProvider(
+          create: (_) => DashboardProvider(mockPracticeRepository),
+          child: const DashboardScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Buscar y pulsar el botón de Práctica
+    expect(find.text('Práctica'), findsOneWidget);
+    await tester.tap(find.text('Práctica'));
+    await tester.pumpAndSettle();
+
+    // Verificar que se ha navegado a la pantalla correcta
+    expect(find.byKey(const Key('practice-screen')), findsOneWidget);
+    expect(find.text('Pantalla de Práctica'), findsOneWidget);
+  });
+
+  testWidgets('Navegación al hacer tap en botón de Análisis en dashboard', (
+    tester,
+  ) async {
+    // Configurar el mock
+    when(
+      () => mockPracticeRepository.getAllSessions(),
+    ).thenReturn(mockSessions);
+
+    // Preparar mapa de rutas para pruebas de navegación
+    final mockRoutes = {
+      '/analysis': (context) => const Scaffold(
+        key: Key('analysis-screen'),
+        body: Center(child: Text('Pantalla de Análisis')),
+      ),
+    };
+
+    // Crear el widget bajo test con el provider
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: mockRoutes,
+        home: ChangeNotifierProvider(
+          create: (_) => DashboardProvider(mockPracticeRepository),
+          child: const DashboardScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Buscar y pulsar el botón de Análisis
+    expect(find.text('Análisis'), findsOneWidget);
+    await tester.tap(find.text('Análisis'));
+    await tester.pumpAndSettle();
+
+    // Verificar que se ha navegado a la pantalla correcta
+    expect(find.byKey(const Key('analysis-screen')), findsOneWidget);
+    expect(find.text('Pantalla de Análisis'), findsOneWidget);
+  });
+
+  testWidgets('Navegación al hacer tap en botón de Exportar en dashboard', (
+    tester,
+  ) async {
+    // Configurar el mock
+    when(
+      () => mockPracticeRepository.getAllSessions(),
+    ).thenReturn(mockSessions);
+
+    // Preparar mapa de rutas para pruebas de navegación
+    final mockRoutes = {
+      '/export': (context) => const Scaffold(
+        key: Key('export-screen'),
+        body: Center(child: Text('Pantalla de Exportación')),
+      ),
+    };
+
+    // Crear el widget bajo test con el provider
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: mockRoutes,
+        home: ChangeNotifierProvider(
+          create: (_) => DashboardProvider(mockPracticeRepository),
+          child: const DashboardScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Buscar y pulsar el botón de Exportar
+    expect(find.text('Exportar'), findsOneWidget);
+    await tester.tap(find.text('Exportar'));
+    await tester.pumpAndSettle();
+
+    // Verificar que se ha navegado a la pantalla correcta
+    expect(find.byKey(const Key('export-screen')), findsOneWidget);
+    expect(find.text('Pantalla de Exportación'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Este PR implementa las acciones rápidas para iniciar sesión, ver análisis y exportar datos en el dashboard según lo especificado en el issue #44.

## Cambios realizados
- Se confirmó que los botones de acceso rápido (Práctica, Análisis, Exportar) ya estaban implementados en `dashboard_screen.dart` en el método `_buildQuickAccessButtons()`.
- Se añadieron pruebas de integración para verificar que la navegación funciona correctamente al hacer tap en los botones.

## Criterios de aceptación
- ✅ Botones de acceso directo visibles en el dashboard.
- ✅ Navegación fluida a cada módulo (Práctica, Análisis, Exportar).
- ✅ Pruebas de integración de navegación añadidas.

## Tests
- Se ejecutaron todas las pruebas y pasaron correctamente.
- Se añadieron pruebas específicas para verificar la navegación desde los botones.

Cierra #44